### PR TITLE
FIX: Restarting docker no longer resets config

### DIFF
--- a/docker/setup_php.sh
+++ b/docker/setup_php.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
+echo "Step 01 - Updating Container"
 apt-get update
 apt-get -y install libicu-dev wget git zip unzip
+echo "Step 02 - Installing PHP Modules"
 docker-php-ext-install intl
 docker-php-ext-install mysqli
 docker-php-ext-install pdo_mysql
-echo install composer
+COMPOSER_FILE=/var/www/html/composer.phar
+if [ ! -f "$COMPOSER_FILE" ]; then
+echo "Step 03 - Installing Composer"
 chmod +x /var/www/html/docker/install_composer.sh
 /var/www/html/docker/install_composer.sh
 php composer.phar install
+echo "Step 04 - Building Silverstripe Vendor Components"
 php /var/www/html/vendor/silverstripe/framework/cli-script.php dev/build
+echo "Step 05 - Hydrating Custom Configuration"
 /var/www/html/vendor/bin/sake dev/tasks/HydrateCustomConfig
+echo "Step 06 - Running SDLT Setup Tasks"
 /var/www/html/vendor/bin/sake dev/tasks/SetupSDLTDataTask
+else
+echo "Skipping steps 03-06. Not required (from /docker/install_php.sh)"
+fi
+echo "Step 07 - Starting PHP"
 chown -R www-data public
 docker-php-entrypoint php-fpm


### PR DESCRIPTION
Fixes: https://github.com/NZTA/SDLT/issues/30

Restarting a docker container would reset changes to the base configuration because it'd do a re-import. Now it checks if composer is present and if so, skips the importing of configuration.